### PR TITLE
Pin transitive dependencies of vaadin-lumo-styles

### DIFF
--- a/vaadin-menu-bar-flow/pom.xml
+++ b/vaadin-menu-bar-flow/pom.xml
@@ -67,6 +67,26 @@
             <artifactId>vaadin-lumo-styles</artifactId>
             <version>1.4.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.polymerelements</groupId>
+            <artifactId>iron-meta</artifactId>
+            <version>2.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.polymerelements</groupId>
+            <artifactId>iron-flex-layout</artifactId>
+            <version>2.0.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.polymerelements</groupId>
+            <artifactId>iron-icon</artifactId>
+            <version>2.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.polymerelements</groupId>
+            <artifactId>iron-iconset-svg</artifactId>
+            <version>2.2.1</version>
+        </dependency>
 
         <dependency>
             <groupId>com.vaadin</groupId>


### PR DESCRIPTION
Some leftover webjar dependencies to pin.

Noticed after the snapshot build failed in `Step: Fail if non-pinned dependencies found`:
https://bender.vaadin.com/viewLog.html?buildId=47825&buildTypeId=Flow_ComponentSnapshot_MenuBar&tab=buildLog&_focus=180