### PR TITLE
Pin missing webjar dependencies

### DIFF
--- a/vaadin-menu-bar-flow/pom.xml
+++ b/vaadin-menu-bar-flow/pom.xml
@@ -64,6 +64,11 @@
         </dependency>
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>
+            <artifactId>vaadin-control-state-mixin</artifactId>
+            <version>2.1.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.vaadin</groupId>
             <artifactId>vaadin-material-styles</artifactId>
             <version>1.2.2</version>
         </dependency>
@@ -75,6 +80,11 @@
         <dependency>
             <groupId>org.webjars.bowergithub.polymerelements</groupId>
             <artifactId>iron-meta</artifactId>
+            <version>2.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.polymerelements</groupId>
+            <artifactId>iron-resizable-behavior</artifactId>
             <version>2.1.1</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
Noticed from failing snapshot build:
https://bender.vaadin.com/viewLog.html?buildId=51164&buildTypeId=Flow_ComponentSnapshot_MenuBar&tab=buildLog