### PR TITLE
Rename ellipsis-button to overflow-button

### DIFF
--- a/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
+++ b/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
@@ -48,9 +48,9 @@ public class MenuBarPageIT extends AbstractComponentIT {
     }
 
     @Test
-    public void ellipsisButtonNotRendered() {
-        Assert.assertNull("Ellipsis button was unexpectedly found",
-                menuBar.getEllipsisButton());
+    public void overflowButtonNotRendered() {
+        Assert.assertNull("Overflow button was unexpectedly found",
+                menuBar.getOverflowButton());
     }
 
     @Test
@@ -141,15 +141,15 @@ public class MenuBarPageIT extends AbstractComponentIT {
     }
 
     @Test
-    public void buttonsOverflow_itemsMovedToEllipsisSubMenu() {
+    public void buttonsOverflow_itemsMovedToOverflowSubMenu() {
         click("set-width");
         click("add-root-item");
-        TestBenchElement ellipsisButton = menuBar.getEllipsisButton();
-        Assert.assertNotNull("Expected the ellipsis button to be rendered",
-                ellipsisButton);
+        TestBenchElement overflowButton = menuBar.getOverflowButton();
+        Assert.assertNotNull("Expected the overflow button to be rendered",
+                overflowButton);
         assertButtonContents("item 1");
 
-        ellipsisButton.click();
+        overflowButton.click();
         verifyOpened();
         Assert.assertArrayEquals(new String[] { "<p>item 2</p>", "added item" },
                 getOverlayMenuItemContents());
@@ -171,7 +171,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
     @Test
     public void buttonWithClickListenerOverflows_clickListenerWorksInSubMenu() {
         click("set-width");
-        menuBar.getEllipsisButton().click();
+        menuBar.getOverflowButton().click();
         getOverlayMenuItems().get(0).click();
         assertMessage("clicked item 2");
     }
@@ -179,7 +179,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
     @Test
     public void overflow_openAndClose_unOverflow_clickButton_listenerCalled() {
         click("set-width");
-        menuBar.getEllipsisButton().click();
+        menuBar.getOverflowButton().click();
         verifyOpened();
         clickBody();
         click("reset-width");
@@ -220,7 +220,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
     public void disableItem_overflow_itemDisabled() {
         click("toggle-disable");
         click("set-width");
-        menuBar.getEllipsisButton().click();
+        menuBar.getOverflowButton().click();
         verifyOpened();
         assertDisabled(getOverlayMenuItems().get(0), true);
     }
@@ -229,12 +229,12 @@ public class MenuBarPageIT extends AbstractComponentIT {
     public void overflow_disableItem_itemDisabled() {
         click("set-width");
         click("toggle-disable");
-        menuBar.getEllipsisButton().click();
+        menuBar.getOverflowButton().click();
         verifyOpened();
         assertDisabled(getOverlayMenuItems().get(0), true);
         // repeat
         clickBody();
-        menuBar.getEllipsisButton().click();
+        menuBar.getOverflowButton().click();
         verifyOpened();
         assertDisabled(getOverlayMenuItems().get(0), true);
     }
@@ -244,7 +244,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
     public void disable_overflow_openAndClose_unOverflow_buttonDisabled() {
         click("toggle-disable");
         click("set-width");
-        menuBar.getEllipsisButton().click();
+        menuBar.getOverflowButton().click();
         verifyOpened();
         clickBody();
         click("reset-width");

--- a/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
+++ b/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
@@ -20,7 +20,6 @@ import java.util.List;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
@@ -240,7 +239,6 @@ public class MenuBarPageIT extends AbstractComponentIT {
     }
 
     @Test
-    @Ignore // https://github.com/vaadin/vaadin-menu-bar/issues/41
     public void disable_overflow_openAndClose_unOverflow_buttonDisabled() {
         click("toggle-disable");
         click("set-width");

--- a/vaadin-menu-bar-flow-testbench/src/main/java/com/vaadin/flow/component/menubar/testbench/MenuBarElement.java
+++ b/vaadin-menu-bar-flow-testbench/src/main/java/com/vaadin/flow/component/menubar/testbench/MenuBarElement.java
@@ -31,32 +31,32 @@ public class MenuBarElement extends TestBenchElement {
     /**
      * Gets the button elements wrapping the root level items. This does not
      * include the overflowing items which are rendered in a sub menu, nor the
-     * ellipsis button which opens the sub menu.
+     * overflow button which opens the sub menu.
      *
      * @return the button elements in the menu bar
      */
     public List<TestBenchElement> getButtons() {
-        return $("vaadin-menu-bar-button").all().stream()
-                .filter(element -> !isEllipsis(element) && isVisible(element))
+        return $("vaadin-menu-bar-button").all().stream().filter(
+                element -> !isOverflowButton(element) && isVisible(element))
                 .collect(Collectors.toList());
     }
 
     /**
-     * Gets the ellipsis button which opens the sub menu of overflowing items,
-     * or {@code null} if the ellipsis button is not visible.
+     * Gets the button which opens the sub menu of overflowing items, or
+     * {@code null} if the overflow button is not visible.
      * 
-     * @return the ellipsis button which opens the sub menu of overflowing items
+     * @return the button which opens the sub menu of overflowing items
      */
-    public TestBenchElement getEllipsisButton() {
-        TestBenchElement ellipsisButton = $("[part~=ellipsis-button]").first();
-        if (ellipsisButton == null || ellipsisButton.hasAttribute("hidden")) {
+    public TestBenchElement getOverflowButton() {
+        TestBenchElement overflowButton = $("[part~=overflow-button]").first();
+        if (overflowButton == null || overflowButton.hasAttribute("hidden")) {
             return null;
         }
-        return ellipsisButton;
+        return overflowButton;
     }
 
-    private boolean isEllipsis(TestBenchElement element) {
-        return element.getAttribute("part").contains("ellipsis-button");
+    private boolean isOverflowButton(TestBenchElement element) {
+        return element.getAttribute("part").contains("overflow-button");
     }
 
     private boolean isVisible(TestBenchElement element) {

--- a/vaadin-menu-bar-flow/pom.xml
+++ b/vaadin-menu-bar-flow/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>
             <artifactId>vaadin-menu-bar</artifactId>
-            <version>1.0.0-alpha2</version>
+            <version>1.0.0-alpha4</version>
         </dependency>
 
         <dependency>

--- a/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -68,7 +68,7 @@ public class MenuBar extends Component
      * The added {@link MenuItem} component is placed inside a button in the
      * menu bar. If this button overflows the menu bar horizontally, the
      * {@link MenuItem} is moved out of the button, into a context menu openable
-     * via ellipsis button.
+     * via an overflow button at the end of the button row.
      * <p>
      * To add content to the sub menu opened by clicking the root level item,
      * use {@link MenuItem#getSubMenu()}.
@@ -89,7 +89,7 @@ public class MenuBar extends Component
      * The added {@link MenuItem} component is placed inside a button in the
      * menu bar. If this button overflows the menu bar horizontally, the
      * {@link MenuItem} is moved out of the button, into a context menu openable
-     * via ellipsis button.
+     * via an overflow button at the end of the button row.
      * <p>
      * To add content to the sub menu opened by clicking the root level item,
      * use {@link MenuItem#getSubMenu()}.
@@ -109,7 +109,7 @@ public class MenuBar extends Component
      * The added {@link MenuItem} component is placed inside a button in the
      * menu bar. If this button overflows the menu bar horizontally, the
      * {@link MenuItem} is moved out of the button, into a context menu openable
-     * via ellipsis button.
+     * via an overflow button at the end of the button row.
      * <p>
      * To add content to the sub menu opened by clicking the root level item,
      * use {@link MenuItem#getSubMenu()}.
@@ -135,7 +135,7 @@ public class MenuBar extends Component
      * The added {@link MenuItem} component is placed inside a button in the
      * menu bar. If this button overflows the menu bar horizontally, the
      * {@link MenuItem} is moved out of the button, into a context menu openable
-     * via ellipsis button.
+     * via an overflow button at the end of the button row.
      * <p>
      * To add content to the sub menu opened by clicking the root level item,
      * use {@link MenuItem#getSubMenu()}.


### PR DESCRIPTION
The renaming affects JavaDocs and TestBench API

Waiting for https://github.com/vaadin/vaadin-menu-bar/pull/56 to be released