### PR TITLE
Bump context-menu version to fix non-pinned deps error

### DIFF
--- a/vaadin-menu-bar-flow/pom.xml
+++ b/vaadin-menu-bar-flow/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>
             <artifactId>vaadin-context-menu</artifactId>
-            <version>4.3.2</version>
+            <version>4.3.5</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>


### PR DESCRIPTION
The version is already pinned but now it's selected from a constraint
for some reason, causing the snapshot build to fail.