### PR TITLE
Prevent hidden item buttons from being rendered

### DIFF
--- a/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
+++ b/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTestPage.java
@@ -83,8 +83,12 @@ public class MenuBarTestPage extends Div {
                         .forEach(item -> item.setEnabled(!item.isEnabled())));
         disableButton.setId("toggle-disable");
 
+        NativeButton visibleButton = new NativeButton("toggle visible item 2",
+                e -> item2.setVisible(!item2.isVisible()));
+        visibleButton.setId("toggle-visible");
+
         add(new Hr(), addRootItemButton, addSubItemButton, removeItemButton,
                 openOnHoverButton, setWidthButton, resetWidthButton,
-                disableButton);
+                disableButton, visibleButton);
     }
 }

--- a/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
+++ b/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
@@ -56,9 +56,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
     public void clickRootButton_subMenuRenders() {
         menuBar.getButtons().get(0).click();
         verifyOpened();
-        Assert.assertArrayEquals(
-                new String[] { "sub item 1", "<p>sub item 2</p>" },
-                getOverlayMenuItemContents());
+        assertOverlayContents("sub item 1", "<p>sub item 2</p>");
     }
 
     @Test
@@ -122,8 +120,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
         click("add-sub-item");
         menuBar.$("vaadin-menu-bar-button").get(1).click();
         verifyNumOfOverlays(1);
-        Assert.assertArrayEquals(new String[] { "added sub item" },
-                getOverlayMenuItemContents());
+        assertOverlayContents("added sub item");
     }
 
     @Test
@@ -150,8 +147,7 @@ public class MenuBarPageIT extends AbstractComponentIT {
 
         overflowButton.click();
         verifyOpened();
-        Assert.assertArrayEquals(new String[] { "<p>item 2</p>", "added item" },
-                getOverlayMenuItemContents());
+        assertOverlayContents("<p>item 2</p>", "added item");
     }
 
     @Test
@@ -249,6 +245,38 @@ public class MenuBarPageIT extends AbstractComponentIT {
         assertButtonDisabled(1, true);
     }
 
+    @Test
+    public void toggleItemVisible_buttonRemovedAndAdded() {
+        click("toggle-visible");
+        assertButtonContents("item 1");
+        click("toggle-visible");
+        assertButtonContents("item 1", "<p>item 2</p>");
+    }
+
+    @Test
+    public void hiddenItemOverflows_overflowButtonNotRendered() {
+        click("toggle-visible");
+        click("set-width");
+        Assert.assertNull(menuBar.getOverflowButton());
+    }
+
+    @Test
+    public void itemsOverflow_toggleItemVisible_visibleStateCorrectInOverlay() {
+        click("add-root-item");
+        click("set-width");
+        click("toggle-visible");
+
+        menuBar.getOverflowButton().click();
+        assertOverlayContents("added item");
+
+        clickBody();
+        verifyClosed();
+        click("toggle-visible");
+
+        menuBar.getOverflowButton().click();
+        assertOverlayContents("<p>item 2</p>", "added item");
+    }
+
     @After
     public void afterTest() {
         checkLogsForErrors();
@@ -309,6 +337,10 @@ public class MenuBarPageIT extends AbstractComponentIT {
 
     private void verifyOpened() {
         waitForElementPresent(By.tagName(OVERLAY_TAG));
+    }
+
+    private void assertOverlayContents(String... expected) {
+        Assert.assertArrayEquals(expected, getOverlayMenuItemContents());
     }
 
     private String[] getOverlayMenuItemContents() {

--- a/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -246,7 +246,7 @@ public class MenuBar extends Component
                         .collect(Collectors.toList()));
     }
 
-    private void resetContent() {
+    void resetContent() {
         menuItemsArrayGenerator.generate();
         updateButtons();
     }
@@ -257,13 +257,20 @@ public class MenuBar extends Component
         }
         String script = //@formatter:off
 
-            // 1. Propagate disabled state from items to parent buttons
+            // 1. Remove hidden items entirely from the array. Just hiding them
+            //    could cause the overflow button to be rendered without items.
+            //    resetContent needs to be called to make buttons visible again.
+            "$0.items = $0.items.filter(function(i){" +
+                "return !i.component.hidden;" +
+            "});" +
+
+            // 2. Propagate disabled state from items to parent buttons
             "$0.items.forEach(function(i){" +
                 "i.disabled = i.component.disabled;" +
             "});" +
             "$0.render();"+
 
-            // 2. Propagate click events from the menu buttons to the item components
+            // 3. Propagate click events from the menu buttons to the item components
             "$0._buttons.forEach(function(b){" +
                 "if(b.item && b.item.component){" +
                     "b.addEventListener('click',function(e){" +

--- a/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarRootItem.java
+++ b/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarRootItem.java
@@ -43,4 +43,10 @@ class MenuBarRootItem extends MenuItem {
         super.setEnabled(enabled);
         menuBar.updateButtons();
     }
+
+    @Override
+    public void setVisible(boolean visible) {
+        super.setVisible(visible);
+        menuBar.resetContent();
+    }
 }


### PR DESCRIPTION
Fix #24

Note: Only propagating the hidden-attribute from item to button would
cause the overflow-button to be rendered when the overlay would have
only invisible items. This is why the hidden items are entirely removed
from the items-array. As a tradeoff, it might be unexpected that a
hidden element is not in the DOM at all.