### PR TITLE
Update to latest web component, fix click events

### DIFF
--- a/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
+++ b/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarPageIT.java
@@ -60,6 +60,14 @@ public class MenuBarPageIT extends AbstractComponentIT {
     }
 
     @Test
+    public void clickRootItem_subMenuRenders() {
+        menuBar.getButtons().get(0).$("vaadin-context-menu-item").first()
+                .click();
+        verifyOpened();
+        assertOverlayContents("sub item 1", "<p>sub item 2</p>");
+    }
+
+    @Test
     public void clickRootButton_hoverOnParentItem_subSubMenuRenders() {
         openSubSubMenu();
 
@@ -151,15 +159,30 @@ public class MenuBarPageIT extends AbstractComponentIT {
     }
 
     @Test
-    public void clickRootButtonWithClickListener_listenerCalled() {
+    public void clickRootButtonWithClickListener_listenerCalledOnce() {
         menuBar.getButtons().get(1).click();
         assertMessage("clicked item 2");
     }
 
     @Test
-    public void changeItems_clickRootButtonWithClickListener_clickListenerCalled() {
+    public void clickRootItemWithClickListener_listenerCalledOnce() {
+        menuBar.getButtons().get(1).$("vaadin-context-menu-item").first()
+                .click();
+        assertMessage("clicked item 2");
+    }
+
+    @Test
+    public void changeItems_clickRootButtonWithClickListener_clickListenerCalledOnce() {
         click("add-root-item");
         menuBar.getButtons().get(1).click();
+        assertMessage("clicked item 2");
+    }
+
+    @Test
+    public void changeItems_clickRootItemWithClickListener_clickListenerCalledOnce() {
+        click("add-root-item");
+        menuBar.getButtons().get(1).$("vaadin-context-menu-item").first()
+                .click();
         assertMessage("clicked item 2");
     }
 
@@ -172,13 +195,25 @@ public class MenuBarPageIT extends AbstractComponentIT {
     }
 
     @Test
-    public void overflow_openAndClose_unOverflow_clickButton_listenerCalled() {
+    public void overflow_openAndClose_unOverflow_clickButton_listenerCalledOnce() {
         click("set-width");
         menuBar.getOverflowButton().click();
         verifyOpened();
         clickBody();
         click("reset-width");
         menuBar.getButtons().get(1).click();
+        assertMessage("clicked item 2");
+    }
+
+    @Test
+    public void overflow_openAndClose_unOverflow_clickItem_listenerCalledOnce() {
+        click("set-width");
+        menuBar.getOverflowButton().click();
+        verifyOpened();
+        clickBody();
+        click("reset-width");
+        menuBar.getButtons().get(1).$("vaadin-context-menu-item").first()
+                .click();
         assertMessage("clicked item 2");
     }
 

--- a/vaadin-menu-bar-flow/pom.xml
+++ b/vaadin-menu-bar-flow/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>
             <artifactId>vaadin-menu-bar</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
         </dependency>
 
         <dependency>

--- a/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -48,7 +48,7 @@ import com.vaadin.flow.function.SerializableConsumer;
 @JsModule("frontend://menubarConnector.js")
 @HtmlImport("frontend://bower_components/vaadin-menu-bar/src/vaadin-menu-bar.html")
 @JsModule("@vaadin/vaadin-menu-bar/src/vaadin-menu-bar.js")
-@NpmPackage(value = "@vaadin/vaadin-menu-bar", version = "1.0.0")
+@NpmPackage(value = "@vaadin/vaadin-menu-bar", version = "1.0.1")
 public class MenuBar extends Component
         implements HasMenuItems, HasSize, HasStyle, HasTheme {
 

--- a/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
+++ b/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
@@ -43,7 +43,9 @@ window.Vaadin.Flow.menubarConnector = {
         menubar._buttons.forEach(function (button) {
           if (button.item && button.item.component) {
             button.addEventListener('click', function (e) {
-              button.item.component.dispatchEvent(new Event('click'));
+              if (e.path.indexOf(button.item.component) === -1) {
+                button.item.component.click();
+              }
             });
           }
         });


### PR DESCRIPTION
The items are now clickable, so the click events should be propagated
only when it's fired only on the button but not the item.

Added tests for firing clicks also on the item and not only on the
button.