### PR TITLE
Fix connector tryCatchWrapper definition

### DIFF
--- a/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
+++ b/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
@@ -16,7 +16,9 @@
 
 (function () {
   const tryCatchWrapper = function (callback) {
-    return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Menu Bar', 'vaadin-menu-bar-flow');
+    return (...args) => {
+      return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Menu Bar', 'vaadin-menu-bar-flow')(...args);
+    };
   };
 
   window.Vaadin.Flow.menubarConnector = {


### PR DESCRIPTION
Connected to https://github.com/vaadin/vaadin-combo-box-flow/issues/313
Make the `Flow.tryCatchWrapper` called lazily.