### PR TITLE
Bump web component dependency to 1.0.5

### DIFF
--- a/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -44,7 +44,7 @@ import com.vaadin.flow.function.SerializableConsumer;
 @Tag("vaadin-menu-bar")
 @JsModule("./menubarConnector.js")
 @JsModule("@vaadin/vaadin-menu-bar/src/vaadin-menu-bar.js")
-@NpmPackage(value = "@vaadin/vaadin-menu-bar", version = "1.0.3")
+@NpmPackage(value = "@vaadin/vaadin-menu-bar", version = "1.0.5")
 public class MenuBar extends Component
         implements HasMenuItems, HasSize, HasStyle, HasTheme {
 


### PR DESCRIPTION
This version previously failed, let's see if it passes now.