### PR TITLE
Add vaadin-prereleases as pluginRepository (#85)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,15 @@
             <url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
         </repository>
     </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>vaadin-prereleases</id>
+            <url>https://maven.vaadin.com/vaadin-prereleases</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 
     <profiles>
         <profile>


### PR DESCRIPTION
cherry-pick to fix 14.2 snapshot build